### PR TITLE
Fix pagination current page

### DIFF
--- a/src/UnionPaginator.php
+++ b/src/UnionPaginator.php
@@ -165,6 +165,10 @@ class UnionPaginator
         if (!$this->unionQuery) {
             $this->prepareUnionQuery();
         }
+        
+        if (is_null($page)) {
+            $page = LengthAwarePaginator::resolveCurrentPage($pageName);
+        }
 
         $paginated = $this->executePagination($perPage, $columns, $pageName, $page);
 


### PR DESCRIPTION
Hello,

Actually the paginate method in the UnionPaginator.php accept page parameter as nullable.

If we dont pass the page, the paginator always returning the first page data.

```php
    public function paginate(int $perPage = 15, array|string $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginator
    {
        if (!$this->unionQuery) {
            $this->prepareUnionQuery();
        }
        
        if (is_null($page)) {
            $page = LengthAwarePaginator::resolveCurrentPage($pageName);
        }
```

I've added a small code to retrieve the page if no value passed.

Thanks