### PR TITLE
Correctly handle global scopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,19 +24,19 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/pagination": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "ext-json": "*",
-        "larastan/larastan": "^2.9",
-        "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7.0|^8.0",
-        "pestphp/pest": "^2.0",
-        "phpunit/phpunit": "^10.0"
+        "larastan/larastan": "^3.0",
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.0|^3.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0
+        "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/src/UnionPaginator.php
+++ b/src/UnionPaginator.php
@@ -199,7 +199,7 @@ class UnionPaginator
     protected function executePagination(int $perPage, array|string $columns, string $pageName, ?int $page): LengthAwarePaginator
     {
         $items = DB::table(DB::raw("({$this->unionQuery->toSql()}) as subquery"))
-            ->mergeBindings($this->unionQuery->getQuery())
+            ->mergeBindings($this->unionQuery->toBase())
             ->forPage($page, $perPage)
             ->get($columns);
 

--- a/tests/UnionPaginatorTest.php
+++ b/tests/UnionPaginatorTest.php
@@ -2,6 +2,8 @@
 
 namespace AustinW\UnionPaginator\Tests;
 
+use AustinW\UnionPaginator\Database\Factories\PostModelFactory;
+use AustinW\UnionPaginator\Database\Factories\UserModelFactory;
 use AustinW\UnionPaginator\Tests\TestClasses\Models\CommentModel;
 use AustinW\UnionPaginator\Tests\TestClasses\Models\PostModel;
 use AustinW\UnionPaginator\Tests\TestClasses\Models\UserModel;
@@ -9,7 +11,11 @@ use AustinW\UnionPaginator\UnionPaginator;
 use BadMethodCallException;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
@@ -647,5 +653,50 @@ class UnionPaginatorTest extends TestCase
         // We expect that posts has already been loaded on the model
         $this->assertTrue($items[0]->relationLoaded('posts'));
         $this->assertCount(3, $items[0]->posts);
+    }
+
+    public function test_fetch_models_using_global_scopes()
+    {
+        // When the paginated models utilise global scopes, the paginator should correctly apply those scopes.
+
+        $comment = CommentModel::factory()
+            ->recycle(UserModel::factory()->create(['email' => 'foo@test.com']))
+            ->create();
+
+        $comment2 = CommentModel::factory()
+            ->recycle(UserModel::factory()->create(['email' => 'bar@test.com']))
+            ->create();
+
+        $paginator = UnionPaginator::forModels([PostModelWithGlobalScope::class, CommentModelWithGlobalScope::class]);
+
+        $items = $paginator->paginate()->items();
+
+        $this->assertCount(2, $items);
+
+        $this->assertEquals(CommentModelWithGlobalScope::class, get_class($items[0]));
+        $this->assertEquals($comment->id, $items[0]->id);
+
+        $this->assertEquals(PostModelWithGlobalScope::class, get_class($items[1]));
+        $this->assertEquals($comment->post_id, $items[1]->id);
+    }
+}
+
+#[ScopedBy(TestScope::class)]
+class PostModelWithGlobalScope extends PostModel
+{
+    public $table = 'post_models';
+}
+
+#[ScopedBy(TestScope::class)]
+class CommentModelWithGlobalScope extends CommentModel
+{
+    public $table = 'comment_models';
+}
+
+class TestScope implements Scope
+{
+    public function apply(EloquentBuilder $builder, Model $model): void
+    {
+        $builder->whereRelation('user', 'email', 'foo@test.com');
     }
 }


### PR DESCRIPTION
This PR fixes the issue described in #3 where models utilising global scopes were not selected correctly. On sqlite this bug resulted in an incorrect number of models being selected, while on mysql connections (and others) an `Invalid parameter count` exception was thrown.

The fix is to change

```
->mergeBindings($this->unionQuery->getQuery())
```
to
```
->mergeBindings($this->unionQuery->toBase())
```

This ensures the bindings for both models are merged correctly and results in the expected number of returned items as demonstrated in the accompanying test.